### PR TITLE
added comma removal from query string

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -8,7 +8,7 @@ module.exports = (pluginContext) => {
     },
     search: (query, env = {}) => {
       return new Promise((resolve, reject) => {
-        const answer = mathjs.eval(query).toString()
+        const answer = mathjs.eval(query.replace(/\,/g,"")).toString()
         const value = answer.match(/[\d.]+/g).join('')
         const title = answer.replace(/\d+/, (v) => {
           return numeral(v).format('0,0')


### PR DESCRIPTION
This adds a quick string replacement to remove a comma from a query expression to allow the calculator function to be used with commas.